### PR TITLE
Fix missing redirect error handling

### DIFF
--- a/src/streamseeker/api/streams/aniworldto/aniworldto.py
+++ b/src/streamseeker/api/streams/aniworldto/aniworldto.py
@@ -379,7 +379,9 @@ class AniworldtoStream(StreamBase):
         links = soup.findAll('li', {"data-lang-key": language_key})
 
         if len(links) == 0:
-            return None
+            raise LinkUrlError(
+                f"Could not find a Link for <fg=red>{provider}</> and language {language_key} -> <fg=cyan>{url}</>"
+            )
         
         for link in links:
             # Find a tag that contains an i tag with the title "Hoster {provider}"

--- a/src/streamseeker/api/streams/sto/sto.py
+++ b/src/streamseeker/api/streams/sto/sto.py
@@ -380,7 +380,9 @@ class StoStream(StreamBase):
         links = soup.findAll('li', {"data-lang-key": language_key})
 
         if len(links) == 0:
-            return None
+            raise LinkUrlError(
+                f"Could not find a Link for <fg=red>{provider}</> and language {language_key} -> <fg=cyan>{url}</>"
+            )
         
         for link in links:
             # Find a tag that contains an i tag with the title "Hoster {provider}"


### PR DESCRIPTION
## Summary
- raise `LinkUrlError` when no redirect links are found for selected provider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d638b5948321acf3f4fd2c3bd181